### PR TITLE
OTA AVR ISP (optional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,23 @@ Don't forget to change the board values in the Arduino environment (menu Tools -
 For flashing you will need to connect the USB to Serial converter to Rx and Tx pins and put CH_PD high (3.3V) and GPIO15 low (GND).
 Put GPIO0 low (GND) and reset the chip just before flashing begins. This is a standard procedure and you can find details anywhere on the Internet.
 If you are using modules with USB connection (NodeMCU, e.g.), all you have to do is to connect the module to your USB port. 
+
+## Optional OTA AVR ISP
+
+If enabled, the WiFi SPI firmware can upload a sketch over WiFi to attached AVR microcontroller. [ESP8266AVRISP library](https://github.com/esp8266/Arduino/tree/master/libraries/ESP8266AVRISP) is used. 
+
+OTA AVR ISP requires a connection from esp8266 pin to AVR reset pin. Default in the firmware source code is pin 4 (labeled D2 on NodeMCU and Wemos boards).
+
+For OTA AVR ISP the esp8266 must be connected to network from start. [WiFiManager library](https://github.com/tzapu/WiFiManager) is used to handle the connection. With WiFi Manager active, do not use WiFiSpi.begin() in the AVR sketch. Only wait while `WiFiSpi.status() != WL_CONNECTED`.
+
+For OTA upload from the IDE, change the key `tools.avrdude.upload.network_pattern` in `hardware/arduino/avr/platform.txt` in Arduino IDE installation folder to
+```
+tools.avrdude.upload.network_pattern="{cmd.path}" "-C{config.path}" -p{build.mcu} -c{upload.protocol} "-Pnet:{serial.port}:328" "-Uflash:w:{build.path}/{build.project_name}.with_bootloader.hex:i"
+```
+Note the with_bootloader.hex. ISP programming doesn't need a bootloader and it erases an existing one. Using hex with bootloader ensures the bootloader for serial upload over USB.
+
+To enabled OTA AVR ISP, uncomment the `#define OTA_AVRISP` in WiFiSPIESP.ino before uploading the firmware.
+ 
  
 ## ToDo and Wish Lists
 

--- a/WiFiSPIESP/SPISlave.cpp
+++ b/WiFiSPIESP/SPISlave.cpp
@@ -75,6 +75,14 @@ void SPISlaveClass::begin()
     hspi_slave_onStatusSent(&_s_status_tx);
     hspi_slave_begin(4, this);
 }
+void SPISlaveClass::end()
+{
+    hspi_slave_onData(NULL);
+    hspi_slave_onDataSent(NULL);
+    hspi_slave_onStatus(NULL);
+    hspi_slave_onStatusSent(NULL);
+    hspi_slave_end();
+}
 void SPISlaveClass::setData(uint8_t * data, size_t len)
 {
     if(len > 32) {

--- a/WiFiSPIESP/SPISlave.h
+++ b/WiFiSPIESP/SPISlave.h
@@ -53,6 +53,7 @@ public:
     {}
     ~SPISlaveClass() {}
     void begin();
+    void end();
     void setData(uint8_t * data, size_t len);
     void setData(const char * data)
     {

--- a/WiFiSPIESP/hspi_slave.c
+++ b/WiFiSPIESP/hspi_slave.c
@@ -98,6 +98,23 @@ void hspi_slave_begin(uint8_t status_len, void * arg)
     ETS_SPI_INTR_ENABLE();
 }
 
+void hspi_slave_end()
+{
+  ETS_SPI_INTR_DISABLE();
+  ETS_SPI_INTR_ATTACH(_hspi_slave_isr_handler, NULL);
+
+  pinMode(SS, INPUT);
+  pinMode(SCK, INPUT);
+  pinMode(MISO, INPUT);
+  pinMode(MOSI, INPUT);
+
+  // defaults
+  SPI1S = 0;
+  SPI1U = SPIUSSE | SPIUCOMMAND;
+  SPI1S1 = 0;
+  SPI1P = B110;
+}
+
 void ICACHE_RAM_ATTR hspi_slave_setStatus(uint32_t status)
 {
     SPI1WS = status;

--- a/WiFiSPIESP/hspi_slave.h
+++ b/WiFiSPIESP/hspi_slave.h
@@ -26,6 +26,9 @@
 //Start SPI SLave
 void hspi_slave_begin(uint8_t status_len, void * arg);
 
+//End SPI SLave
+void hspi_slave_end();
+
 //set the status register so the master can read it
 void hspi_slave_setStatus(uint32_t status);
 


### PR DESCRIPTION
I [discovered](http://forum.arduino.cc/index.php?topic=524853.msg3579696) your WiFi SPI system for esp8266 3 days ago. In my free time I maintain WiFi Link and I was working on OTA AVR ISP support. But in WiFi Link it is complicated.
In your firmware the integration of OTA upload was easy, once I had the SPISlave.end() ready.
For SPISlave library I have a pull request with SPISlave.end(). In your firmware I added it to spi slave source files.
Everything in this pull request is a clean addition and optional with a `#define`. The code added in loop() is copied from AVRISP example with two lines added: the SPISlave.end() and ESP.reset().